### PR TITLE
feat: Add Stochastic Oscillator and ATR indicators

### DIFF
--- a/README.md
+++ b/README.md
@@ -131,6 +131,7 @@ This server exposes the following tools, categorized by whether they require API
 *   **`fetch_option_contract_data`**: Fetches market data for an options contract.
 *   **`fetch_market_ticker`**: Fetches the latest price ticker data for a symbol.
 *   **`fetch_public_market_trades`**: Fetches recent public trades for a symbol.
+*   **`calculate_technical_indicator_tool`**: Fetches OHLCV data and calculates a specified technical indicator (e.g., RSI, SMA, EMA, MACD, Bollinger Bands, Stochastic Oscillator, Average True Range (ATR)).
 
 Each tool has detailed parameter descriptions available via the MCP protocol itself, thanks to the use of `Annotated` and `pydantic.Field`.
 


### PR DESCRIPTION
This commit introduces two new technical indicators to the `calculate_technical_indicator_tool`:
1.  Stochastic Oscillator (%K and %D)
2.  Average True Range (ATR)

The following changes were made:
- Added `compute_stochastic_oscillator` function to calculate %K and %D lines.
- Added `compute_atr` function to calculate ATR using Wilder's smoothing.
- Integrated both indicators into the `calculate_technical_indicator_tool`, including:
    - Updating indicator name Literals and parameter descriptions.
    - Adding helper functions (`calculate_stochastic_indicator`, `format_stochastic_to_list`, `calculate_atr_indicator`) for processing and formatting.
    - Modifying `calculate_technical_indicator_tool` to handle these new indicators and their specific multi-price source requirements (high, low, close).
- Updated `README.md` to list Stochastic Oscillator and ATR as supported indicators.